### PR TITLE
feat(pool): implemented connection pooling to allow parallel requests…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
-*.zip
 umls.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG UMLS_API_KEY
 WORKDIR /app
 COPY . .
 
+# Copy the UMLS ZIP file if it exists
+COPY umls-2023AB-full.zip ./
+
 RUN apk add --no-cache make curl
 RUN make build
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ umls.db: umls-2023AB-full.zip
 	go run cmd/build.go
 
 umls-2023AB-full.zip:
-	curl "https://uts-ws.nlm.nih.gov/download?url=https://download.nlm.nih.gov/umls/kss/2023AB/umls-2023AB-metathesaurus-full.zip&apiKey=$(UMLS_API_KEY)" -o umls-2023AB-full.zip
-
+	@if [ ! -f umls-2023AB-full.zip ]; then \
+		curl "https://uts-ws.nlm.nih.gov/download?url=https://download.nlm.nih.gov/umls/kss/2023AB/umls-2023AB-metathesaurus-full.zip&apiKey=$(UMLS_API_KEY)" -o umls-2023AB-full.zip; \
+	fi
 # ===== Commands =====
 
 build: umls.db

--- a/internal/sqlite.go
+++ b/internal/sqlite.go
@@ -1,28 +1,35 @@
 package internal
 
 import (
+	"fmt"
 	"zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitex"
 )
 
 type DB struct {
-	conn *sqlite.Conn
+	pool *sqlitex.Pool
 }
 
 func NewDB(path string) (*DB, error) {
-	conn, err := sqlite.OpenConn(path, sqlite.OpenCreate, sqlite.OpenReadWrite)
+	pool, err := sqlitex.Open(path, sqlite.OpenCreate|sqlite.OpenReadWrite, 10)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DB{
-		conn: conn,
+		pool: pool,
 	}, nil
 }
 
 func (db *DB) Query(query string, args ...any) ([]Row, error) {
+	conn := db.pool.Get(nil)
+	if conn == nil {
+		return nil, fmt.Errorf("failed to get a database connection from the pool")
+	}
+	defer db.pool.Put(conn)
+
 	var results []Row
-	err := sqlitex.Execute(db.conn, query, &sqlitex.ExecOptions{
+	err := sqlitex.Execute(conn, query, &sqlitex.ExecOptions{
 		Args: args,
 		ResultFunc: func(stmt *sqlite.Stmt) error {
 			results = append(results, ParseRow(stmt))
@@ -33,23 +40,60 @@ func (db *DB) Query(query string, args ...any) ([]Row, error) {
 }
 
 func (db *DB) Close() error {
-	return db.conn.Close()
+	return db.pool.Close()
 }
 
-func (db *DB) Batch() error {
-	return sqlitex.Execute(db.conn, "BEGIN", &sqlitex.ExecOptions{
-		ResultFunc: func(stmt *sqlite.Stmt) error {
-			return nil
-		},
-	})
+func (db *DB) Batch(conn *sqlite.Conn) error {
+    if conn == nil {
+        return fmt.Errorf("no database connection provided")
+    }
+
+	return sqlitex.Execute(conn, "BEGIN", &sqlitex.ExecOptions{
+        ResultFunc: func(stmt *sqlite.Stmt) error {
+            return nil
+        },
+    })
 }
 
-func (db *DB) Flush() error {
-	return sqlitex.Execute(db.conn, "COMMIT", &sqlitex.ExecOptions{
-		ResultFunc: func(stmt *sqlite.Stmt) error {
-			return nil
-		},
+func (db *DB) Flush(conn *sqlite.Conn) error {
+    if conn == nil {
+        return fmt.Errorf("no database connection provided")
+    }
+
+	return sqlitex.Execute(conn, "COMMIT", &sqlitex.ExecOptions{
+        ResultFunc: func(stmt *sqlite.Stmt) error {
+            return nil
+        },
 	})
+}
+ 
+
+func (db *DB) GetConnection() (*sqlite.Conn, error) {
+    conn := db.pool.Get(nil)
+    if conn == nil {
+        return nil, fmt.Errorf("failed to get a database connection from the pool")
+    }
+    return conn, nil
+}
+
+func (db *DB) PutConnection(conn *sqlite.Conn) {
+    db.pool.Put(conn)
+}
+
+func (db *DB) QueryWithConnection(conn *sqlite.Conn, query string, args ...any) ([]Row, error) {
+    if conn == nil {
+        return nil, fmt.Errorf("no database connection provided")
+    }
+
+    var results []Row
+    err := sqlitex.Execute(conn, query, &sqlitex.ExecOptions{
+        Args: args,
+        ResultFunc: func(stmt *sqlite.Stmt) error {
+            results = append(results, ParseRow(stmt))
+            return nil
+        },
+    })
+    return results, err
 }
 
 type Row map[string]any

--- a/k6.js
+++ b/k6.js
@@ -1010,7 +1010,7 @@ export default function () {
   const n = Math.floor(Math.random() * 1000)
   const code = codes[n] || codes[0];
   const test = testData[code];
-
+  
   let res = http.get("http://localhost:29927/R4/CodeSystem/$lookup?system=http://snomed.info/sct&code=" + code);
 
   // Validate response


### PR DESCRIPTION
This PR introduces connection pooling for the sqlite db, to allow simultaneous requests. Previously, simultaneous requests would cause SegFaults in the server: 

```
2024-02-23 16:03:39 goroutine 2910438 [running]:
2024-02-23 16:03:39 net/http.(*conn).serve.func1()
2024-02-23 16:03:39     /usr/local/go/src/net/http/server.go:1868 +0xb0
2024-02-23 16:03:39 panic({0x40e120?, 0x7d9ec0?})
2024-02-23 16:03:39     /usr/local/go/src/runtime/panic.go:920 +0x26c
2024-02-23 16:03:39 modernc.org/libc.Xstrlen(...)
2024-02-23 16:03:39     /go/pkg/mod/modernc.org/libc@v1.29.0/libc.go:698
2024-02-23 16:03:39 modernc.org/sqlite/lib.Xsqlite3Strlen30(0xffffffffffffffff?, 0x0?)
2024-02-23 16:03:39     /go/pkg/mod/modernc.org/sqlite@v1.27.0/lib/sqlite_linux_arm64.go:13288 +0x20
2024-02-23 16:03:39 modernc.org/sqlite/lib.Xsqlite3VdbeExec(0x4000110b40, 0xffff5ef00228)
2024-02-23 16:03:39     /go/pkg/mod/modernc.org/sqlite@v1.27.0/lib/sqlite_linux_arm64.go:48497 +0x654
2024-02-23 16:03:39 modernc.org/sqlite/lib.sqlite3Step(0x16?, 0xffff5ef00228)
2024-02-23 16:03:39     /go/pkg/mod/modernc.org/sqlite@v1.27.0/lib/sqlite_linux_arm64.go:43694 +0x68
2024-02-23 16:03:39 modernc.org/sqlite/lib.Xsqlite3_step(0x455601?, 0xffff5ef00228)
2024-02-23 16:03:39     /go/pkg/mod/modernc.org/sqlite@v1.27.0/lib/sqlite_linux_arm64.go:43769 +0xb4
2024-02-23 16:03:39 zombiezen.com/go/sqlite.(*Stmt).step(0x400006e540)
2024-02-23 16:03:39     /go/pkg/mod/zombiezen.com/go/sqlite@v1.0.0/sqlite.go:769 +0xb4
2024-02-23 16:03:39 zombiezen.com/go/sqlite.(*Stmt).Step(0x400006e540)
2024-02-23 16:03:39     /go/pkg/mod/zombiezen.com/go/sqlite@v1.0.0/sqlite.go:755 +0xb0
2024-02-23 16:03:39 zombiezen.com/go/sqlite/sqlitex.exec(0x400006e540, 0x3, 0x4000093900)
2024-02-23 16:03:39     /go/pkg/mod/zombiezen.com/go/sqlite@v1.0.0/sqlitex/exec.go:293 +0x294
2024-02-23 16:03:39 zombiezen.com/go/sqlite/sqlitex.Execute(0xffff5fe21878?, {0x465b44?, 0x10?}, 0x4000080000?)
2024-02-23 16:03:39     /go/pkg/mod/zombiezen.com/go/sqlite@v1.0.0/sqlitex/exec.go:123 +0x74
2024-02-23 16:03:39 github.com/mattwiller/hawthorn/internal.(*DB).Query(0x400004e0e8, {0x465b44, 0x30}, {0x40000cba78, 0x1, 0x1})
2024-02-23 16:03:39     /app/internal/sqlite.go:25 +0xa0
2024-02-23 16:03:39 main.main.CodeSystemLookupHandler.func1({0x507f98, 0x4000368d20}, 0x40000cbae8?)
2024-02-23 16:03:39     /app/internal/fhir/codesystem_lookup.go:22 +0x114
2024-02-23 16:03:39 net/http.HandlerFunc.ServeHTTP(0x40000cbb08?, {0x507f98?, 0x4000368d20?}, 0x1ddc28?)
2024-02-23 16:03:39     /usr/local/go/src/net/http/server.go:2136 +0x38
2024-02-23 16:03:39 net/http.(*ServeMux).ServeHTTP(0x81cde0?, {0x507f98, 0x4000368d20}, 0x400012f000)
2024-02-23 16:03:39     /usr/local/go/src/net/http/server.go:2514 +0x144
2024-02-23 16:03:39 net/http.serverHandler.ServeHTTP({0x4000251c80?}, {0x507f98?, 0x4000368d20?}, 0x6?)
2024-02-23 16:03:39     /usr/local/go/src/net/http/server.go:2938 +0xbc
2024-02-23 16:03:39 net/http.(*conn).serve(0x400051c870, {0x5085f0, 0x4000161f50})
2024-02-23 16:03:39     /usr/local/go/src/net/http/server.go:2009 +0x518
2024-02-23 16:03:39 created by net/http.(*Server).Serve in goroutine 1
2024-02-23 16:03:39     /usr/local/go/src/net/http/server.go:3086 +0x4cc
2024-02-23 16:03:39 unexpected fault address 0xffff5f8ffcc8
2024-02-23 16:03:39 fatal error: fault
2024-02-23 16:03:39 [signal SIGSEGV: segmentation violation code=0x1 
```

This PR fixes that